### PR TITLE
Show/hide editor button dynamically

### DIFF
--- a/addons/SMRT/SMRT.gd
+++ b/addons/SMRT/SMRT.gd
@@ -8,6 +8,8 @@ var show_editor_btn
 var editor_tscn = preload("res://addons/SMRT/editor.tscn")
 var editor_btn
 var editor
+var selection
+
 func _init():
 	editor_btn = ToolButton.new()
 
@@ -15,6 +17,9 @@ func _ready():
 	editor_btn.set_button_icon(preload("icon.png"))
 	editor_btn.set_text("SMRT-Editor")
 	editor_btn.connect("pressed",self,"_open_editor")
+	editor_btn.hide()
+	selection = get_selection()
+	selection.connect("selection_changed", self, "_selection_changed")
 
 func _enter_tree():
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU,editor_btn)
@@ -25,6 +30,7 @@ func _exit_tree():
 # As the release of this plugin, there is no oposite function 
 # to "add_control_to_container" so for now it is not possible to remove a control from a container,
 # only the custom type
+	editor_btn.queue_free()
 	remove_custom_type("SMRT-Dialog")
 	
 
@@ -35,3 +41,11 @@ func _open_editor():
 	editor.popup_centered()
 	print("OPENING EDITOR!")
 	print("===============")
+
+
+func _selection_changed():
+	for select in selection.get_selected_nodes():
+		if select extends preload("res://addons/SMRT/dialog.gd"):
+			editor_btn.show()
+			return
+	editor_btn.hide()


### PR DESCRIPTION
Hi, I was using your plugin as an example to create a plugin with container button and I saw the comment about a function that removes the control from the container.

It worked fine using a simple `queue_free()` in the `_exit_tree` method `.

As I was looking for a button that shows/hides dynamically I added it on your plugin to show only if the custom node is selected. If you don't want/need this feature feel free to close this PR, it's just a suggestion.

Thanks o>